### PR TITLE
Regroup useful internal functions in utils.go

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,7 +1,6 @@
 package kinesis
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"sync"
@@ -88,7 +87,7 @@ func (r *recordBuffer) Add(m *router.Message) error {
 	}
 
 	// Partition key
-	pKey, err := pKey(r.pKeyTmpl, m)
+	pKey, err := executeTmpl(r.pKeyTmpl, m)
 	if err != nil {
 		return err
 	}
@@ -140,14 +139,4 @@ func (r *recordBuffer) reset() {
 
 	log.Printf("kinesis: buffer reset, stream name: %s, length: %d\n",
 		*r.input.StreamName, len(r.input.Records))
-}
-
-func pKey(tmpl *template.Template, m *router.Message) (string, error) {
-	var pKey bytes.Buffer
-	err := tmpl.Execute(&pKey, m)
-	if err != nil {
-		return "", err
-	}
-
-	return pKey.String(), nil
 }

--- a/buffer.go
+++ b/buffer.go
@@ -30,7 +30,7 @@ type recordBuffer struct {
 }
 
 func newRecordBuffer(client *kinesis.Kinesis, streamName string) (*recordBuffer, error) {
-	pKeyTmpl, err := compileTmpl("KINESIS_PARTITION_KEY_TEMPLATE", "partition key")
+	pKeyTmpl, err := compileTmpl("KINESIS_PARTITION_KEY_TEMPLATE")
 	if err != nil {
 		return nil, err
 	}

--- a/buffer.go
+++ b/buffer.go
@@ -2,10 +2,8 @@ package kinesis
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"log"
-	"os"
 	"sync"
 	"text/template"
 
@@ -33,7 +31,7 @@ type recordBuffer struct {
 }
 
 func newRecordBuffer(client *kinesis.Kinesis, streamName string) (*recordBuffer, error) {
-	pKeyTmpl, err := pKeyTmpl()
+	pKeyTmpl, err := compileTmpl("KINESIS_PARTITION_KEY_TEMPLATE", "partition key")
 	if err != nil {
 		return nil, err
 	}
@@ -48,20 +46,6 @@ func newRecordBuffer(client *kinesis.Kinesis, streamName string) (*recordBuffer,
 		pKeyTmpl: pKeyTmpl,
 		input:    input,
 	}, nil
-}
-
-func pKeyTmpl() (*template.Template, error) {
-	pKeyTmplString := os.Getenv("KINESIS_PARTITION_KEY_TEMPLATE")
-	if pKeyTmplString == "" {
-		return nil, errors.New("The partition key template is missing. Please set the KINESIS_PARTITION_KEY_TEMPLATE env variable")
-	}
-
-	pKeyTmpl, err := template.New("kinesisPartitionKey").Parse(pKeyTmplString)
-	if err != nil {
-		return nil, err
-	}
-
-	return pKeyTmpl, nil
 }
 
 type recordSizeLimitError struct {

--- a/kinesis.go
+++ b/kinesis.go
@@ -22,7 +22,7 @@ type KinesisAdapter struct {
 func NewKinesisAdapter(route *router.Route) (router.LogAdapter, error) {
 	drainers := make(map[string]*Drainer)
 	client := kinesis.New(&aws.Config{})
-	tmpl, err := compileTmpl("KINESIS_STREAM_TEMPLATE", "stream template")
+	tmpl, err := compileTmpl("KINESIS_STREAM_TEMPLATE")
 	if err != nil {
 		return nil, err
 	}

--- a/kinesis.go
+++ b/kinesis.go
@@ -84,17 +84,3 @@ func (a *KinesisAdapter) FlushAll() []error {
 
 	return err
 }
-
-func logErr(err error) {
-	if err != nil {
-		log.Println("kinesis: ", err.Error())
-	}
-}
-
-func logErrs(err []error) {
-	if err != nil {
-		for _, e := range err {
-			log.Println("kinesis: ", e.Error())
-		}
-	}
-}

--- a/kinesis.go
+++ b/kinesis.go
@@ -1,7 +1,6 @@
 package kinesis
 
 import (
-	"bytes"
 	"log"
 	"text/template"
 
@@ -58,7 +57,7 @@ func (a *KinesisAdapter) findDrainer(m *router.Message) (*Drainer, error) {
 	var d *Drainer
 	var ok bool
 
-	streamName, err := streamName(a.StreamTmpl, m)
+	streamName, err := executeTmpl(a.StreamTmpl, m)
 	if err != nil {
 		return nil, err
 	}
@@ -84,16 +83,6 @@ func (a *KinesisAdapter) FlushAll() []error {
 	}
 
 	return err
-}
-
-func streamName(tmpl *template.Template, m *router.Message) (string, error) {
-	var streamName bytes.Buffer
-	err := tmpl.Execute(&streamName, m)
-	if err != nil {
-		return "", err
-	}
-
-	return streamName.String(), nil
 }
 
 func logErr(err error) {

--- a/kinesis.go
+++ b/kinesis.go
@@ -2,9 +2,7 @@ package kinesis
 
 import (
 	"bytes"
-	"errors"
 	"log"
-	"os"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -25,7 +23,7 @@ type KinesisAdapter struct {
 func NewKinesisAdapter(route *router.Route) (router.LogAdapter, error) {
 	drainers := make(map[string]*Drainer)
 	client := kinesis.New(&aws.Config{})
-	tmpl, err := streamTmpl()
+	tmpl, err := compileTmpl("KINESIS_STREAM_TEMPLATE", "stream template")
 	if err != nil {
 		return nil, err
 	}
@@ -86,20 +84,6 @@ func (a *KinesisAdapter) FlushAll() []error {
 	}
 
 	return err
-}
-
-func streamTmpl() (*template.Template, error) {
-	streamTmplString := os.Getenv("KINESIS_STREAM_TEMPLATE")
-	if streamTmplString == "" {
-		return nil, errors.New("The stream name template is missing. Please set the KINESIS_STREAM_TEMPLATE env variable")
-	}
-
-	streamTmpl, err := template.New("kinesisStream").Parse(streamTmplString)
-	if err != nil {
-		return nil, err
-	}
-
-	return streamTmpl, nil
 }
 
 func streamName(tmpl *template.Template, m *router.Message) (string, error) {

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,12 @@
 package kinesis
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"text/template"
+
+	"github.com/gliderlabs/logspout/router"
 )
 
 type missingEnvVarError struct {
@@ -27,4 +30,14 @@ func compileTmpl(envVar string, tmplName string) (*template.Template, error) {
 	}
 
 	return tmpl, nil
+}
+
+func executeTmpl(tmpl *template.Template, m *router.Message) (string, error) {
+	var res bytes.Buffer
+	err := tmpl.Execute(&res, m)
+	if err != nil {
+		return "", err
+	}
+
+	return res.String(), nil
 }

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package kinesis
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"text/template"
 
@@ -40,4 +41,18 @@ func executeTmpl(tmpl *template.Template, m *router.Message) (string, error) {
 	}
 
 	return res.String(), nil
+}
+
+func logErr(err error) {
+	if err != nil {
+		log.Println("kinesis: ", err.Error())
+	}
+}
+
+func logErrs(err []error) {
+	if err != nil {
+		for _, e := range err {
+			log.Println("kinesis: ", e.Error())
+		}
+	}
 }

--- a/utils.go
+++ b/utils.go
@@ -11,18 +11,17 @@ import (
 )
 
 type missingEnvVarError struct {
-	envVar   string
-	tmplName string
+	envVar string
 }
 
 func (e *missingEnvVarError) Error() string {
-	return fmt.Sprintf("The %s template is missing. Please set the %s env variable\n", e.tmplName, e.envVar)
+	return fmt.Sprintf("Missing required %s environment variable.\n", e.envVar)
 }
 
-func compileTmpl(envVar string, tmplName string) (*template.Template, error) {
+func compileTmpl(envVar string) (*template.Template, error) {
 	tmplString := os.Getenv(envVar)
 	if tmplString == "" {
-		return nil, &missingEnvVarError{envVar: envVar, tmplName: tmplName}
+		return nil, &missingEnvVarError{envVar: envVar}
 	}
 
 	tmpl, err := template.New("").Parse(tmplString)
@@ -52,7 +51,7 @@ func logErr(err error) {
 func logErrs(err []error) {
 	if err != nil {
 		for _, e := range err {
-			log.Println("kinesis: ", e.Error())
+			logErr(e)
 		}
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,30 @@
+package kinesis
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+)
+
+type missingEnvVarError struct {
+	envVar   string
+	tmplName string
+}
+
+func (e *missingEnvVarError) Error() string {
+	return fmt.Sprintf("The %s template is missing. Please set the %s env variable\n", e.tmplName, e.envVar)
+}
+
+func compileTmpl(envVar string, tmplName string) (*template.Template, error) {
+	tmplString := os.Getenv(envVar)
+	if tmplString == "" {
+		return nil, &missingEnvVarError{envVar: envVar, tmplName: tmplName}
+	}
+
+	tmpl, err := template.New("").Parse(tmplString)
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpl, nil
+}


### PR DESCRIPTION
Just regroup/factor a few functions in utils.go. Replace individual template compilation and execution by the one function for each.
