### PR TITLE
Add lookUp utility function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ For instance, you can decide to assign a Kinesis stream for each of you app (ass
 $ export KINESIS_STREAM_TEMPLATE={{ index .Container.Config.Labels "app" }}
 ```
 
+Or you can use environment variables, with our provided lookUp template function:
+```console
+$ export KINESIS_STREAM_TEMPLATE={{ lookUp .Container.Config.Env "APP_ID" }}
+```
+
+This will search through `.Container.Config.Env` for `APP_ID=*` and return the value after the `=`.
+
 You can similarly decide the format of your partition key for each of your stream (here the app name and process type):
 ```console
 $ export KINESIS_PARTITION_KEY_TEMPLATE={{ index .Container.Config.Labels "app" }}.{{ index .Container.Config.Labels "process.type" }}

--- a/utils.go
+++ b/utils.go
@@ -5,10 +5,15 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/gliderlabs/logspout/router"
 )
+
+var funcMap = template.FuncMap{
+	"lookUp": lookUp,
+}
 
 type missingEnvVarError struct {
 	envVar string
@@ -24,7 +29,7 @@ func compileTmpl(envVar string) (*template.Template, error) {
 		return nil, &missingEnvVarError{envVar: envVar}
 	}
 
-	tmpl, err := template.New("").Parse(tmplString)
+	tmpl, err := template.New("").Funcs(funcMap).Parse(tmplString)
 	if err != nil {
 		return nil, err
 	}
@@ -40,6 +45,18 @@ func executeTmpl(tmpl *template.Template, m *router.Message) (string, error) {
 	}
 
 	return res.String(), nil
+}
+
+// lookUp searches into an array of environment variable by key,
+// and returns the value.
+func lookUp(arr []string, key string) string {
+	for _, v := range arr {
+		parts := strings.Split(v, "=")
+		if key == parts[0] {
+			return parts[1]
+		}
+	}
+	return ""
 }
 
 func logErr(err error) {


### PR DESCRIPTION
Add a lookup function to search an array of env variables by key and returns the value.

So we can easily extract values from a docker container. For instance:

``` console
KINESIS_STREAM_TEMPLATE={{ lookUp .Container.Config.Env "EMPIRE_APPID" }}
```
