### PR TITLE
Tag stream after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [Logspout](https://github.com/gliderlabs/logspout) adapter for writing Docker container logs to [Amazon Kinesis](http://aws.amazon.com/kinesis/).
 
-## usage 
+## usage
 After you created your custom Logspout build (see below), you can just run it as:
 ```console
 $ 	docker run --rm \
@@ -38,11 +38,22 @@ $ export KINESIS_PARTITION_KEY_TEMPLATE={{ index .Container.Config.Labels "app" 
 ### stream creation
 By default, **logspout-kinesis** doesn't create a stream if it is missing from Kinesis. You can enable this by creating an environment variable `KINESIS_STREAM_CREATION` and set it to `true`.
 
+### stream tagging
+By default, **logspout-kinesis** doesn't tag a stream it just created. You can enable this by creating an environment variable `KINESIS_TAG_STREAM` and set it to `true`.
+Then you can set the `KINESIS_STREAM_TAG_KEY` environment variable to set the tag key, and the `KINESIS_STREAM_TAG_VALUE` variable to set the template you want to use for the tag value.
+
+A complete example would be:
+```console
+KINESIS_TAG_STREAM=true
+KINESIS_STREAM_TAG_KEY="app"
+KINESIS_STREAM_TAG_VALUE={{ lookUp .Container.Config.Env "EMPIRE_APPNAME" }}
+```
+
 ### logging
 To activate logging, set the `KINESIS_DEBUG` environment variable to `true`.
 
 ## build
-**logspout-kinesis** is a custom logspout module. To use it, create an empty Dockerfile based on `gliderlabs/logspout:master`, and import this `logspout-kinesis` package into a new `modules.go` file. The `gliderlabs/logspout` base image will `ONBUILD COPY` and replace the original `modules.go`. 
+**logspout-kinesis** is a custom logspout module. To use it, create an empty Dockerfile based on `gliderlabs/logspout:master`, and import this `logspout-kinesis` package into a new `modules.go` file. The `gliderlabs/logspout` base image will `ONBUILD COPY` and replace the original `modules.go`.
 
 The following example creates a minimal logspout image capable of writing Dockers logs to Kinesis:
 

--- a/drainer.go
+++ b/drainer.go
@@ -80,32 +80,29 @@ func waitForActive(a *KinesisAdapter, d *Drainer, m *router.Message) {
 }
 
 func tagStream(a *KinesisAdapter, streamName string, m *router.Message) error {
-	if os.Getenv("KINESIS_TAG_STREAM") == "true" {
-		if tagKey := os.Getenv("KINESIS_STREAM_TAG_KEY"); tagKey != "" {
-			tmpl, err := compileTmpl("KINESIS_STREAM_TAG_VALUE")
-			if err != nil {
-				return err
-			}
-
-			tagValue, err := executeTmpl(tmpl, m)
-			if err != nil {
-				return err
-			}
-
-			tags := map[string]*string{
-				tagKey: aws.String(tagValue),
-			}
-
-			params := &kinesis.AddTagsToStreamInput{
-				StreamName: aws.String(streamName),
-				Tags:       tags,
-			}
-
-			_, err = a.Client.AddTagsToStream(params)
+	if tagKey := os.Getenv("KINESIS_STREAM_TAG_KEY"); tagKey != "" {
+		tmpl, err := compileTmpl("KINESIS_STREAM_TAG_VALUE")
+		if err != nil {
 			return err
 		}
 
-		return nil
+		tagValue, err := executeTmpl(tmpl, m)
+		if err != nil {
+			return err
+		}
+
+
+		tags := map[string]*string{
+			tagKey: aws.String(tagValue),
+		}
+
+		params := &kinesis.AddTagsToStreamInput{
+			StreamName: aws.String(streamName),
+			Tags:       tags,
+		}
+
+		_, err = a.Client.AddTagsToStream(params)
+		return err
 	}
 
 	return nil

--- a/drainer.go
+++ b/drainer.go
@@ -1,6 +1,7 @@
 package kinesis
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -91,6 +92,9 @@ func tagStream(a *KinesisAdapter, streamName string, m *router.Message) error {
 			return err
 		}
 
+		if tagValue == "" {
+			return fmt.Errorf("The tag value is empty, check your template KINESIS_STREAM_TAG_VALUE.")
+		}
 
 		tags := map[string]*string{
 			tagKey: aws.String(tagValue),

--- a/drainer.go
+++ b/drainer.go
@@ -7,13 +7,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/gliderlabs/logspout/router"
 )
 
 type Drainer struct {
 	Buffer *recordBuffer
 }
 
-func newDrainer(a *KinesisAdapter, streamName string) {
+func newDrainer(a *KinesisAdapter, streamName string, m *router.Message) {
 	buffer, err := newRecordBuffer(a.Client, streamName)
 	if err != nil {
 		logErr(err)
@@ -23,7 +24,7 @@ func newDrainer(a *KinesisAdapter, streamName string) {
 	go d.Drain()
 
 	if os.Getenv("KINESIS_STREAM_CREATION") == "true" {
-		createStream(a, d, streamName)
+		createStream(a, d, streamName, m)
 	} else {
 		a.addDrainer(streamName, d)
 	}
@@ -36,7 +37,7 @@ func (d *Drainer) Drain() {
 	}
 }
 
-func createStream(a *KinesisAdapter, d *Drainer, streamName string) {
+func createStream(a *KinesisAdapter, d *Drainer, streamName string, m *router.Message) {
 	_, err := a.Client.CreateStream(&kinesis.CreateStreamInput{
 		ShardCount: aws.Int64(1),
 		StreamName: aws.String(streamName),
@@ -54,11 +55,11 @@ func createStream(a *KinesisAdapter, d *Drainer, streamName string) {
 		}
 	} else {
 		debugLog("kinesis: need to create stream for %s", streamName)
-		waitForActive(a, d)
+		waitForActive(a, d, m)
 	}
 }
 
-func waitForActive(a *KinesisAdapter, d *Drainer) {
+func waitForActive(a *KinesisAdapter, d *Drainer, m *router.Message) {
 	streamName := *d.Buffer.input.StreamName
 	var streamStatus string
 
@@ -67,6 +68,7 @@ func waitForActive(a *KinesisAdapter, d *Drainer) {
 	for {
 		resp, _ = a.Client.DescribeStream(params)
 		if streamStatus = *resp.StreamDescription.StreamStatus; streamStatus == "ACTIVE" {
+			logErr(tagStream(a, streamName, m))
 			a.addDrainer(streamName, d)
 			break
 		} else {
@@ -75,4 +77,36 @@ func waitForActive(a *KinesisAdapter, d *Drainer) {
 
 		debugLog("kinesis: status for stream %s: %s", streamName, streamStatus)
 	}
+}
+
+func tagStream(a *KinesisAdapter, streamName string, m *router.Message) error {
+	if os.Getenv("KINESIS_TAG_STREAM") == "true" {
+		if tagKey := os.Getenv("KINESIS_STREAM_TAG_KEY"); tagKey != "" {
+			tmpl, err := compileTmpl("KINESIS_STREAM_TAG_VALUE")
+			if err != nil {
+				return err
+			}
+
+			tagValue, err := executeTmpl(tmpl, m)
+			if err != nil {
+				return err
+			}
+
+			tags := map[string]*string{
+				tagKey: aws.String(tagValue),
+			}
+
+			params := &kinesis.AddTagsToStreamInput{
+				StreamName: aws.String(streamName),
+				Tags:       tags,
+			}
+
+			_, err = a.Client.AddTagsToStream(params)
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
 }

--- a/kinesis.go
+++ b/kinesis.go
@@ -62,7 +62,7 @@ func (a *KinesisAdapter) Stream(logstream chan *router.Message) {
 			logErr(d.Buffer.Add(m))
 		} else {
 			if _, ok := a.Launched[streamName]; !ok {
-				go newDrainer(a, streamName)
+				go newDrainer(a, streamName, m)
 				a.Launched[streamName] = true
 			}
 		}


### PR DESCRIPTION
If you activate the option, this allow you to automatically tag a stream after its creation, for instance, tag it by the app name it is linked to.
