### PR TITLE
Introduce a process key and a writer per process

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ type Client interface {
 	Create(*kinesis.CreateStreamInput) (bool, error)
 	Status(*kinesis.DescribeStreamInput) string
 	Tag(*kinesis.AddTagsToStreamInput) error
+	Kinesis() *kinesis.Kinesis
 }
 
 type client struct {
@@ -44,4 +45,8 @@ func (c *client) Tag(input *kinesis.AddTagsToStreamInput) error {
 	}
 
 	return nil
+}
+
+func (c *client) Kinesis() *kinesis.Kinesis {
+	return c.kinesis
 }

--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ type Client interface {
 	Create(*kinesis.CreateStreamInput) (bool, error)
 	Status(*kinesis.DescribeStreamInput) string
 	Tag(*kinesis.AddTagsToStreamInput) error
-	Kinesis() *kinesis.Kinesis
+	PutRecords(inp *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error)
 }
 
 type client struct {
@@ -47,6 +47,6 @@ func (c *client) Tag(input *kinesis.AddTagsToStreamInput) error {
 	return nil
 }
 
-func (c *client) Kinesis() *kinesis.Kinesis {
-	return c.kinesis
+func (c *client) PutRecords(inp *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error) {
+	return c.kinesis.PutRecords(inp)
 }

--- a/flusher.go
+++ b/flusher.go
@@ -24,12 +24,12 @@ type Flusher interface {
 }
 
 type flusher struct {
-	client        *kinesis.Kinesis
+	client        Client
 	inputs        chan kinesis.PutRecordsInput
 	dropInputFunc func(kinesis.PutRecordsInput)
 }
 
-func newFlusher(client *kinesis.Kinesis) Flusher {
+func newFlusher(client Client) Flusher {
 	return &flusher{
 		client:        client,
 		inputs:        make(chan kinesis.PutRecordsInput, 10),

--- a/kinesis.go
+++ b/kinesis.go
@@ -18,10 +18,10 @@ var (
 	// ErrorHandler handles the reporting of an error.
 	ErrorHandler = logErr
 
-	// ErrMissingTagKey is returned when the tag key environment variable is missing.
+	// ErrMissingTagKey is returned when the tag key environment variable doesn't match.
 	ErrMissingTagKey = errors.New("the tag key is empty, check your template KINESIS_STREAM_TAG_KEY")
 
-	// ErrMissingTagValue is returned when the tag value environment variable is missing.
+	// ErrMissingTagValue is returned when the tag value environment variable doesn't match.
 	ErrMissingTagValue = errors.New("the tag value is empty, check your template KINESIS_STREAM_TAG_VALUE")
 )
 

--- a/kinesis.go
+++ b/kinesis.go
@@ -31,7 +31,6 @@ type Adapter struct {
 	StreamTmpl *template.Template
 	TagTmpl    *template.Template
 	PKeyTmpl   *template.Template
-	PTmpl      *template.Template
 }
 
 // NewAdapter creates a kinesis adapter. Called during init.
@@ -51,11 +50,6 @@ func NewAdapter(route *router.Route) (router.LogAdapter, error) {
 		return nil, err
 	}
 
-	pTmpl, err := compileTmpl("KINESIS_PROCESS_TEMPLATE")
-	if err != nil {
-		return nil, err
-	}
-
 	streams := make(map[string]*Stream)
 
 	return &Adapter{
@@ -63,7 +57,6 @@ func NewAdapter(route *router.Route) (router.LogAdapter, error) {
 		StreamTmpl: sTmpl,
 		TagTmpl:    tagTmpl,
 		PKeyTmpl:   pKeyTmpl,
-		PTmpl:      pTmpl,
 	}, nil
 }
 
@@ -90,7 +83,7 @@ func (a *Adapter) Stream(logstream chan *router.Message) {
 				break
 			}
 
-			s := NewStream(sn, tags, a.PKeyTmpl, a.PTmpl)
+			s := NewStream(sn, tags, a.PKeyTmpl)
 			s.Start()
 			a.Streams[sn] = s
 		}

--- a/kinesis.go
+++ b/kinesis.go
@@ -31,6 +31,7 @@ type Adapter struct {
 	StreamTmpl *template.Template
 	TagTmpl    *template.Template
 	PKeyTmpl   *template.Template
+	PTmpl      *template.Template
 }
 
 // NewAdapter creates a kinesis adapter. Called during init.
@@ -45,7 +46,12 @@ func NewAdapter(route *router.Route) (router.LogAdapter, error) {
 		return nil, err
 	}
 
-	pTmpl, err := compileTmpl("KINESIS_PARTITION_KEY_TEMPLATE")
+	pKeyTmpl, err := compileTmpl("KINESIS_PARTITION_KEY_TEMPLATE")
+	if err != nil {
+		return nil, err
+	}
+
+	pTmpl, err := compileTmpl("KINESIS_PROCESS_TEMPLATE")
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +62,8 @@ func NewAdapter(route *router.Route) (router.LogAdapter, error) {
 		Streams:    streams,
 		StreamTmpl: sTmpl,
 		TagTmpl:    tagTmpl,
-		PKeyTmpl:   pTmpl,
+		PKeyTmpl:   pKeyTmpl,
+		PTmpl:      pTmpl,
 	}, nil
 }
 
@@ -83,7 +90,7 @@ func (a *Adapter) Stream(logstream chan *router.Message) {
 				break
 			}
 
-			s := NewStream(sn, tags, a.PKeyTmpl)
+			s := NewStream(sn, tags, a.PKeyTmpl, a.PTmpl)
 			s.Start()
 			a.Streams[sn] = s
 		}

--- a/stream.go
+++ b/stream.go
@@ -113,7 +113,7 @@ func (s *Stream) write(m *router.Message) error {
 
 	w := newWriter(
 		newBuffer(s.pKeyTmpl, s.name),
-		newFlusher(s.client.Kinesis()),
+		newFlusher(s.client),
 	)
 	w.start()
 	s.writers[process] = w

--- a/stream_test.go
+++ b/stream_test.go
@@ -41,6 +41,10 @@ func (f *fakeClient) Tag(input *kinesis.AddTagsToStreamInput) error {
 	return f.err
 }
 
+func (f *fakeClient) Kinesis() *kinesis.Kinesis {
+	return nil
+}
+
 // TODO: implement optional stream creation
 // func TestStream_CreationDeactivated(t *testing.T) {
 
@@ -52,7 +56,7 @@ func (f *fakeClient) Tag(input *kinesis.AddTagsToStreamInput) error {
 // }
 
 func TestStream_CreateAlreadyExists(t *testing.T) {
-	s := NewStream("abc", nil, nil)
+	s := NewStream("abc", nil, nil, nil)
 	s.client = &fakeClient{
 		created: true,
 	}
@@ -62,7 +66,7 @@ func TestStream_CreateAlreadyExists(t *testing.T) {
 }
 
 func TestStream_CreateStatusActive(t *testing.T) {
-	s := NewStream("abc", nil, nil)
+	s := NewStream("abc", nil, nil, nil)
 	s.client = &fakeClient{
 		created: false,
 		status:  "ACTIVE",
@@ -73,7 +77,7 @@ func TestStream_CreateStatusActive(t *testing.T) {
 }
 
 func TestStream_CreateError(t *testing.T) {
-	s := NewStream("abc", nil, nil)
+	s := NewStream("abc", nil, nil, nil)
 	s.client = &fakeClient{
 		created: false,
 		err:     awserr.New("RequestError", "500", nil),
@@ -88,7 +92,7 @@ func TestStream_WriteStreamNotReady(t *testing.T) {
 		Data: "hello",
 	}
 
-	s := NewStream("abc", nil, nil)
+	s := NewStream("abc", nil, nil, nil)
 	s.client = &fakeClient{
 		created: false,
 	}
@@ -105,7 +109,7 @@ func TestStream_WriteStreamBecomesReady(t *testing.T) {
 	tags := make(map[string]*string)
 	tags["name"] = aws.String("kinesis-test")
 
-	s := NewStream("abc", &tags, tmpl)
+	s := NewStream("abc", &tags, tmpl, tmpl)
 	fk := &fakeClient{
 		created: false,
 		status:  "CREATING",

--- a/stream_test.go
+++ b/stream_test.go
@@ -41,8 +41,8 @@ func (f *fakeClient) Tag(input *kinesis.AddTagsToStreamInput) error {
 	return f.err
 }
 
-func (f *fakeClient) Kinesis() *kinesis.Kinesis {
-	return nil
+func (f *fakeClient) PutRecords(inp *kinesis.PutRecordsInput) (*kinesis.PutRecordsOutput, error) {
+	return nil, nil
 }
 
 // TODO: implement optional stream creation

--- a/writer_test.go
+++ b/writer_test.go
@@ -6,12 +6,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/kinesis"
+	"github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/logspout/router"
 )
-
-var m = &router.Message{
-	Data: "hello",
-}
 
 type fakeFlusher struct {
 	inputs        chan kinesis.PutRecordsInput
@@ -61,6 +58,13 @@ func TestWriter_Flush(t *testing.T) {
 
 	w.start()
 
+	m := &router.Message{
+		Data: "hello",
+		Container: &docker.Container{
+			ID: "123",
+		},
+	}
+
 	w.write(m)
 	w.write(m)
 	w.write(m)
@@ -88,6 +92,13 @@ func TestWriter_PeriodicFlush(t *testing.T) {
 	w.ticker = ticker
 
 	w.start()
+
+	m := &router.Message{
+		Data: "hello",
+		Container: &docker.Container{
+			ID: "123",
+		},
+	}
 	w.write(m)
 
 	select {


### PR DESCRIPTION
This should allow faster flushering for a given stream, since we have now one writer (and thus one flusher) per process within am app. Effectively introducing multiple flusher per stream. This can increase the write throughput on a stream quite a bit, making it necessary to crank the number of shards (this can be detected by your ErrorHandler function). 

The idea is to allow goroutines to run in parallel (either via compiling with go 1.5 or
setting up the GOMAXPROCS).
