### PR TITLE
Not working with latest logspout:master

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ KINESIS_STREAM_TAG_VALUE={{ lookUp .Container.Config.Env "EMPIRE_APPNAME" }}
 To activate logging, set the `KINESIS_DEBUG` environment variable to `true`.
 
 ## build
-**logspout-kinesis** is a custom logspout module. To use it, create an empty Dockerfile based on `gliderlabs/logspout:master`, and import this `logspout-kinesis` package into a new `modules.go` file. The `gliderlabs/logspout` base image will `ONBUILD COPY` and replace the original `modules.go`.
+**logspout-kinesis** is a custom logspout module. To use it, create an empty Dockerfile based on `gliderlabs/logspout`, and import this `logspout-kinesis` package into a new `modules.go` file. The `gliderlabs/logspout` base image will `ONBUILD COPY` and replace the original `modules.go`.
 
 The following example creates a minimal logspout image capable of writing Dockers logs to Kinesis:
 
@@ -74,7 +74,7 @@ import (
 
 In Dockerfile:
 ```Dockerfile
-FROM gliderlabs/logspout:master
+FROM gliderlabs/logspout:v3
 ```
 
 Final step, build the image:
@@ -82,4 +82,4 @@ Final step, build the image:
 $ docker build -t mycompany/logspout .
 ```
 
-More information on custom modules is available at the Logspout repo: [Custom Logspout Modules](https://github.com/gliderlabs/logspout/blob/master/custom/README.md)
+More information on custom modules is available at the Logspout repo: [Custom Logspout Modules](https://github.com/gliderlabs/logspout/tree/master/custom)


### PR DESCRIPTION
I followed the readme instructions, but could not get this to work. It always fails with `bad adapter: kinesis`:

``` sh
$ docker run --rm -e LOGSPOUT=ignore --name=logspout --volume=/var/run/docker.sock:/var/run/docker.sock example/logspout kinesis://
# logspout v3.1-dev-custom by gliderlabs
# adapters:
# options : persist:/mnt/routes
!! bad adapter: kinesis
```

Repro here: https://github.com/amacneil/logspout-kinesis-example

I fixed it by changing the Dockerfile to `FROM gliderlabs/logspout:v3` (latest stable tag) and it works as expected. Therefore recommend updating the readme to point people at this tag (and probably also look into why the adapter is not being registered correctly with logspout:master).
